### PR TITLE
Add Arxiv as an option for parsing

### DIFF
--- a/apps/api-express/src/app/daos/search.ts
+++ b/apps/api-express/src/app/daos/search.ts
@@ -40,8 +40,7 @@ export async function findQueryResults(
       (paragraph: ParsedArticleParagraph) => {
         return {
           head: article.head,
-          // set default backsUpClaim to notApplicable. This later gets changed manually in the JSON file
-          ...paragraph
+          ...paragraph,
         };
       }
     );

--- a/libs/article-parser/src/lib/parser/arxiv-parser.ts
+++ b/libs/article-parser/src/lib/parser/arxiv-parser.ts
@@ -4,8 +4,7 @@ import {
   ParsedArticleParagraph,
   ArxivOptions,
 } from '@foodmedicine/interfaces';
-import fetch from 'node-fetch'
-import pdf from 'pdf-parse'
+import { getParagraphsFromPDFUrl } from '@foodmedicine/pdf-explorer';
 
 /**
  * A parser for https://www.ebi.ac.uk/europepmc/webservices/rest/
@@ -15,12 +14,8 @@ export const ArxivParser: Parser<ParsedArticle> = {
     if (!opts?.parsedArticleHead) {
       throw 'Please add in the parsed head';
     }
+    const paragraphTexts = await getParagraphsFromPDFUrl(fileUrl);
     try {
-      const fetchRes = await fetch(fileUrl);
-      const buff = await fetchRes.buffer()
-      const pdfData = await pdf(buff)
-      console.log(pdfData);
-      const paragraphTexts: string[] = pdfData.text.split('.');
       const paragraphs: ParsedArticleParagraph[] = paragraphTexts.map(
         (paragraphText) =>
           opts.getCorrelationScore(

--- a/libs/article-parser/src/lib/parser/arxiv-parser.ts
+++ b/libs/article-parser/src/lib/parser/arxiv-parser.ts
@@ -12,7 +12,7 @@ import { getParagraphsFromPDFUrl } from '@foodmedicine/pdf-explorer';
 export const ArxivParser: Parser<ParsedArticle> = {
   parserF: async (fileUrl: string, opts?: ArxivOptions) => {
     if (!opts?.parsedArticleHead) {
-      throw 'Please add in the parsed head';
+      throw new Error('Please add in the parsed head');
     }
     const paragraphTexts = await getParagraphsFromPDFUrl(fileUrl);
     try {

--- a/libs/scholars-scraper/src/lib/parsers/arxiv-parser.ts
+++ b/libs/scholars-scraper/src/lib/parsers/arxiv-parser.ts
@@ -31,7 +31,6 @@ export const ArxivParser: Parser<ParsedArticleHead> = {
         };
       })
       .filter((parsedHead) => parsedHead.fullTextDownloadLink !== null);
-    console.log(parsedHeads[0]);
     return parsedHeads;
   },
 };


### PR DESCRIPTION
- Relies on PR #4 
- Add the [Arxiv](https://arxiv.org/) scholarly DB to the search capabilities
- Generalize the code's structure to better work with multiple parsers
- Add script to run a fullstack dev