### PR TITLE
Group results by articles rather than show individual paragraphs

### DIFF
--- a/apps/api-express/src/app/daos/search.ts
+++ b/apps/api-express/src/app/daos/search.ts
@@ -21,7 +21,7 @@ function groupParagraphsByArticle(
   });
   const parsedByTitle: ParsedArticlesByArticleId[] = Object.keys(byIds)
     .map((id) => {
-      if (!byIds[id] || byIds[id].length === 0) {
+      if (!byIds[id]?.length === 0) {
         return null;
       }
       return {

--- a/apps/api-express/src/app/daos/search.ts
+++ b/apps/api-express/src/app/daos/search.ts
@@ -3,10 +3,55 @@ import {
   ParsedArticle,
   ParsedArticleParagraph,
   ScholarsDB,
+  ParsedArticlesByArticleId,
 } from '@foodmedicine/interfaces';
 import { runScholarsScraper } from '@foodmedicine/scholars-scraper';
 import * as articleParser from '@foodmedicine/article-parser';
-import { cleanString } from '@foodmedicine/word-explorer'
+import { cleanString } from '@foodmedicine/word-explorer';
+
+function groupParagraphsByArticle(
+  articlesStandalone: ParsedArticleParagraphStandalone[]
+): ParsedArticlesByArticleId[] {
+  const byIds: { [key: string]: ParsedArticleParagraphStandalone[] } = {};
+  articlesStandalone.map((articleStandalone) => {
+    if (!byIds[articleStandalone.head.id]) {
+      byIds[articleStandalone.head.id] = [];
+    }
+    byIds[articleStandalone.head.id].push(articleStandalone);
+  });
+  const parsedByTitle: ParsedArticlesByArticleId[] = Object.keys(byIds)
+    .map((id) => {
+      if (!byIds[id] || byIds[id].length === 0) {
+        return null;
+      }
+      return {
+        head: byIds[id][0].head,
+        paragraphs: byIds[id].map((paragraphStandalone) => {
+          return {
+            body: paragraphStandalone.body,
+            correlationScore: paragraphStandalone.correlationScore,
+          };
+        }),
+      } as ParsedArticlesByArticleId;
+    })
+    .filter((item) => item !== null);
+  return parsedByTitle;
+}
+
+function sortParagraphsByArticle(
+  a: ParsedArticlesByArticleId,
+  b: ParsedArticlesByArticleId
+): number {
+  const aTotalScore = a.paragraphs.reduce(
+    (prev, paragraph) => (prev += paragraph.correlationScore),
+    0
+  );
+  const bTotalScore = b.paragraphs.reduce(
+    (prev, paragraph) => (prev += paragraph.correlationScore),
+    0
+  );
+  return bTotalScore - aTotalScore;
+}
 
 export async function findQueryResults(
   query: string,
@@ -14,7 +59,7 @@ export async function findQueryResults(
     numberOfArticles?: number;
     maxNumberOfParagraphs?: number;
   }
-): Promise<ParsedArticleParagraphStandalone[]> {
+): Promise<ParsedArticlesByArticleId[]> {
   const cleanedQuery = cleanString(query);
   const articleHeads = await runScholarsScraper(
     cleanedQuery,
@@ -46,15 +91,20 @@ export async function findQueryResults(
     );
     allParagraphsStandalone.push(...standaloneParagraphs);
   });
-  // Sort in descending order and remove empty items
-  allParagraphsStandalone.sort(
-    (a, b) => b.correlationScore - a.correlationScore
-  );
+  // // Sort in descending order and remove empty items
+  // allParagraphsStandalone.sort(
+  //   (a, b) => b.correlationScore - a.correlationScore
+  // );
   const allParagraphsStandaloneFiltered = allParagraphsStandalone.filter(
     (paragraph) => paragraph.body?.trim().length > 0
   );
-  return allParagraphsStandaloneFiltered.slice(
+  const filteredByLength = allParagraphsStandaloneFiltered.slice(
     0,
     opts?.maxNumberOfParagraphs || allParagraphsStandalone.length
   );
+  const byArticle = groupParagraphsByArticle(filteredByLength);
+  byArticle.map((article) =>
+    article.paragraphs.sort((a, b) => b.correlationScore - a.correlationScore)
+  );
+  return byArticle.sort((a, b) => sortParagraphsByArticle(a, b));
 }

--- a/apps/api-express/src/app/daos/search.ts
+++ b/apps/api-express/src/app/daos/search.ts
@@ -91,10 +91,6 @@ export async function findQueryResults(
     );
     allParagraphsStandalone.push(...standaloneParagraphs);
   });
-  // // Sort in descending order and remove empty items
-  // allParagraphsStandalone.sort(
-  //   (a, b) => b.correlationScore - a.correlationScore
-  // );
   const allParagraphsStandaloneFiltered = allParagraphsStandalone.filter(
     (paragraph) => paragraph.body?.trim().length > 0
   );
@@ -103,6 +99,8 @@ export async function findQueryResults(
     opts?.maxNumberOfParagraphs || allParagraphsStandalone.length
   );
   const byArticle = groupParagraphsByArticle(filteredByLength);
+
+  // sort the individual paragraphs within an article by correlation score
   byArticle.map((article) =>
     article.paragraphs.sort((a, b) => b.correlationScore - a.correlationScore)
   );

--- a/apps/api-frontend/src/app/pages/search-pages/search-result.css
+++ b/apps/api-frontend/src/app/pages/search-pages/search-result.css
@@ -1,4 +1,8 @@
 .app .results-container .single-result-container p {
+  cursor: pointer;
+}
+
+.app .results-container .single-result-container p {
   padding: 1rem;
   text-align: left;
 }

--- a/apps/api-frontend/src/app/pages/search-pages/search-result.css
+++ b/apps/api-frontend/src/app/pages/search-pages/search-result.css
@@ -1,4 +1,14 @@
-.app .results-container .single-result-container p {
+.app .results-container .single-result-container .article-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-evenly;
+}
+.app .results-container .single-result-container .article-actions button {
+  margin: 1rem;
+  min-width: 100px;
+}
+
+.app .results-container .single-result-container h4 {
   cursor: pointer;
 }
 

--- a/apps/api-frontend/src/app/pages/search-pages/search-result.css
+++ b/apps/api-frontend/src/app/pages/search-pages/search-result.css
@@ -5,7 +5,7 @@
 }
 .app .results-container .single-result-container .article-actions button {
   margin: 1rem;
-  min-width: 100px;
+  min-width: 6rem;
 }
 
 .app .results-container .single-result-container h4 {

--- a/apps/api-frontend/src/app/pages/search-pages/search-result.tsx
+++ b/apps/api-frontend/src/app/pages/search-pages/search-result.tsx
@@ -19,19 +19,44 @@ function SingleResult(props: {
   groupedByArticle: ParsedArticlesByArticleId;
   key: string;
 }) {
+  const navToGoogleScholars = () => {
+    window.open(
+      createGoogleScholarsQueryLink(props.groupedByArticle.head.title)
+    );
+  };
+  const [showOverflow, setShowOverflow] = useState(false);
   return (
-    <div
-      className="single-result-container"
-      onClick={() =>
-        window.open(
-          createGoogleScholarsQueryLink(props.groupedByArticle.head.title)
-        )
-      }
-    >
-      <h4 aria-label="paper's title">{props.groupedByArticle.head.title}</h4>
-      {props.groupedByArticle.paragraphs.map((paragraph) => <>
-        <p aria-label="correlated paragraph">...{paragraph.body}...</p>
-      </>)}
+    <div className="single-result-container">
+      <h4 aria-label="paper's title" onClick={() => navToGoogleScholars()}>
+        {props.groupedByArticle.head.title}
+      </h4>
+      {props.groupedByArticle.paragraphs.map((paragraph, i) => (
+        <>
+          <p
+            aria-label="correlated paragraph"
+            style={{
+              display: i >= 2 ? (showOverflow ? 'block' : 'none') : 'block',
+            }}
+          >
+            ...{paragraph.body}...
+          </p>
+        </>
+      ))}
+      <div className="article-actions">
+        {showOverflow && (
+          <button onClick={() => setShowOverflow(false)}>
+            Hide Some of these Paragraphs
+          </button>
+        )}
+        {!showOverflow && (
+          <button onClick={() => setShowOverflow(true)}>
+            Show Me More Paragraphs from this Source
+          </button>
+        )}
+        <button onClick={() => navToGoogleScholars()}>
+          Take Me to the Article
+        </button>
+      </div>
       <hr />
     </div>
   );

--- a/apps/api-frontend/src/app/pages/search-pages/search-result.tsx
+++ b/apps/api-frontend/src/app/pages/search-pages/search-result.tsx
@@ -31,16 +31,14 @@ function SingleResult(props: {
         {props.groupedByArticle.head.title}
       </h4>
       {props.groupedByArticle.paragraphs.map((paragraph, i) => (
-        <>
-          <p
+        <p
             aria-label="correlated paragraph"
             style={{
               display: i >= 2 ? (showOverflow ? 'block' : 'none') : 'block',
             }}
           >
             ...{paragraph.body}...
-          </p>
-        </>
+        </p>
       ))}
       <div className="article-actions">
         {showOverflow && (

--- a/libs/interfaces/src/lib/interfaces.ts
+++ b/libs/interfaces/src/lib/interfaces.ts
@@ -44,6 +44,11 @@ export interface ParsedArticleParagraphStandalone
   head: ParsedArticleHead;
 }
 
+export interface ParsedArticlesByArticleId {
+  head: ParsedArticleHead;
+  paragraphs: ParsedArticleParagraph[];
+}
+
 export interface Parser<IRet> {
   parserF: (inputSource: string, opts?: any) => Promise<IRet[] | IRet>;
 }

--- a/libs/scholars-scraper/src/lib/parsers/arxiv-parser.ts
+++ b/libs/scholars-scraper/src/lib/parsers/arxiv-parser.ts
@@ -17,10 +17,10 @@ export const ArxivParser: Parser<ParsedArticleHead> = {
     const parser = new xmlJs.Parser();
     const jsonRes = await parser.parseStringPromise(xml);
     const allResults = jsonRes.feed.entry || [];
-    const parsedHeads: ParsedArticleHead[] = allResults
+    const parsedHeads: ParsedArticleHead[] = (allResults || [])
       .map((res) => {
-        const pdfDownloadLinks = res.link
-          .filter((linkItem) => linkItem.$.title === 'pdf')
+        const pdfDownloadLinks = (res.link
+          .filter((linkItem) => linkItem.$.title === 'pdf') || [])
           .map((linkItem) => linkItem.$.href);
         const fullTextDownloadLink = pdfDownloadLinks[0] || null;
         return {

--- a/libs/scholars-scraper/src/lib/parsers/europepmc-parser.ts
+++ b/libs/scholars-scraper/src/lib/parsers/europepmc-parser.ts
@@ -17,7 +17,7 @@ export const EuropePMCParser: Parser<ParsedArticleHead> = {
     const parser = new xmlJs.Parser();
     const jsonRes = await parser.parseStringPromise(xml);
     const allResults = jsonRes.responseWrapper.resultList[0].result;
-    const parsedHeads: ParsedArticleHead[] = allResults.map((res) => {
+    const parsedHeads: ParsedArticleHead[] = (allResults || []).map((res) => {
       return {
         id: res.id[0],
         title: res.title[0],


### PR DESCRIPTION
- Return results by highest scoring articles
- Under each article, show the 2 highest scoring paragraphs with the option of expanding to see more or going to the site itself

I cannot link the demo though as that would require deploying to Heroku and would break the current build, I can work on having a stage env later on though. This is issue #14 

